### PR TITLE
Bazel 0.24.1 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/bazel-*
+/.ijwb/
+/.idea/
+/grafana/src/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ add them above the previous block:
 - [`rules_python` setup](https://github.com/bazelbuild/rules_python#setup).
 - [`rules_docker` setup](https://github.com/bazelbuild/rules_docker#setup).
 
+## Bazel compatibility
+
+The current version has only been tested to work with Bazel 0.24.1, but may work with other versions.
+
 ## Usage
 
 `rules_grafana` makes it easy to build dashboards and incorporate them into your Bazel build,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,13 @@
 workspace(name = "io_bazel_rules_grafana")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# rules_python master as of 2019-04-21
+rules_python_version = "f7a96a4756aeda1cd0ece89f9813fc2c393c20a8"
 git_repository(
     name = "io_bazel_rules_python",
-    commit = "8b5d0683a7d878b28fffe464779c8a53659fc645",
+    commit = rules_python_version,
     remote = "https://github.com/bazelbuild/rules_python.git",
 )
 
@@ -10,14 +15,17 @@ load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories")
 
 pip_repositories()
 
-git_repository(
+# rules_docker master as of 2019-04-21
+rules_docker_version = "3332026921c918c9bfaa94052578d0ca578aab66"
+http_archive(
     name = "io_bazel_rules_docker",
-    commit = "70c904e82aff0aa6fa58dd2b735397e81029c9db",
-    remote = "https://github.com/bazelbuild/rules_docker.git",
+    sha256 = "8af10dccb3efab3ecb0ae29cf4f0a55ba2c11d711317ec95ed79793c7774068f",
+    strip_prefix = "rules_docker-%s" % rules_docker_version,
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/%s.tar.gz" % rules_docker_version],
 )
 
 load(
-    "@io_bazel_rules_docker//container:container.bzl",
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
 

--- a/grafana/workspace.bzl
+++ b/grafana/workspace.bzl
@@ -1,13 +1,15 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")
-pip_repositories()
-
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",
-    container_repositories = "repositories",
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+pip_repositories()
 
 def repositories():
     pip_import(


### PR DESCRIPTION
- Updates to rules_python and rules_docker deps
- Use the correct rules_docker repositories
- Put all load statements at the top.