### PR TITLE
you can't safely disable python2 after all

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ git_repository(
 
 load("@io_bazel_rules_grafana//grafana:workspace.bzl", grafana_repositories="repositories")
 grafana_repositories()
-# Load dependencies for python2 and python3.  If you don't use python2, instead call
-#   grafana_repositories(python2_interpreter = None)
-# and skip the load/call of @io_bazel_rules_grafana_deps.
+# Load dependencies for python2 and python3.  If you don't use python2, remove
+# the load/call of @io_bazel_rules_grafana_deps.
 load("@io_bazel_rules_grafana_deps//:requirements.bzl", pip_install_grafana = "pip_install")
 load("@io_bazel_rules_grafana_deps3//:requirements.bzl", pip_install_grafana3 = "pip_install")
 

--- a/grafana/workspace.bzl
+++ b/grafana/workspace.bzl
@@ -33,8 +33,8 @@ def repositories(
     Args:
         grafanalib_pip_specifier: dependencies for grafanalib url.
         use_custom_container: use a custom container for grafana.
-        python2_interpreter: path to python2 for pip; set to None to disable python2 support
-        python3_interpreter: path to python3 for pip; set to None to disable python3 support
+        python2_interpreter: path to python2 for pip
+        python3_interpreter: path to python3 for pip
     """
 
     # `requirements.txt` for `pip_import` must be a file, so turn the argument into one, then import it.
@@ -43,18 +43,16 @@ def repositories(
         requirements = [grafanalib_pip_specifier],
     )
 
-    if python2_interpreter:
-        pip_import(
-            name = "io_bazel_rules_grafana_deps",
-            requirements = "@io_bazel_rules_grafana_dynamic_requirements//:requirements.txt",
-            python_interpreter = python2_interpreter,
-        )
-    if python3_interpreter:
-        pip_import(
-            name = "io_bazel_rules_grafana_deps3",
-            requirements = "@io_bazel_rules_grafana_dynamic_requirements//:requirements.txt",
-            python_interpreter = python3_interpreter,
-        )
+    pip_import(
+        name = "io_bazel_rules_grafana_deps",
+        requirements = "@io_bazel_rules_grafana_dynamic_requirements//:requirements.txt",
+        python_interpreter = python2_interpreter,
+    )
+    pip_import(
+        name = "io_bazel_rules_grafana_deps3",
+        requirements = "@io_bazel_rules_grafana_dynamic_requirements//:requirements.txt",
+        python_interpreter = python3_interpreter,
+    )
 
     container_repositories()
 


### PR DESCRIPTION
the repository needs to exist so it can be loaded in grafana.bzl, at least