### PR TITLE
Migrate grafana_image to rules_oci

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,30 +43,52 @@ load("@io_bazel_rules_grafana_deps//:requirements.bzl", install_deps_grafanalib 
 
 install_deps_grafanalib()
 
-# rules_docker
-rules_docker_version = "0.25.0"
-
+# rules_oci
 http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "07ee8ca536080f5ebab6377fc6e8920e9a761d2ee4e64f0f6d919612f6ab56aa",
-    strip_prefix = "rules_docker-%s" % rules_docker_version,
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v%s.tar.gz" % rules_docker_version],
+    name = "rules_oci",
+    sha256 = "6ae66ccc6261d3d297fef1d830a9bb852ddedd3920bbd131021193ea5cb5af77",
+    strip_prefix = "rules_oci-1.7.0",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.0/rules_oci-v1.7.0.tar.gz",
 )
 
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
+
+rules_oci_dependencies()
+
+load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
+
+oci_register_toolchains(
+    name = "oci",
+    crane_version = LATEST_CRANE_VERSION,
+)
+# end rules_oci
+
+# rules_pkg
+http_archive(
+    name = "rules_pkg",
+    sha256 = "e93b7309591cabd68828a1bcddade1c158954d323be2205063e718763627682a",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.10.0/rules_pkg-0.10.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.10.0/rules_pkg-0.10.0.tar.gz",
+    ],
 )
 
-container_repositories()
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
-load(
-    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
-    container_go_deps = "go_deps",
+rules_pkg_dependencies()
+# end rules_pkg
+
+# container_structure_test
+http_archive(
+    name = "container_structure_test",
+    sha256 = "2da13da4c4fec9d4627d4084b122be0f4d118bd02dfa52857ff118fde88e4faa",
+    strip_prefix = "container-structure-test-1.16.0",
+    urls = ["https://github.com/GoogleContainerTools/container-structure-test/archive/v1.16.0.zip"],
 )
 
-container_go_deps()
+load("@container_structure_test//:repositories.bzl", "container_structure_test_register_toolchain")
+
+container_structure_test_register_toolchain(name = "container_structure_test_toolchain")
 
 # end external rules
 

--- a/grafana/workspace.bzl
+++ b/grafana/workspace.bzl
@@ -1,6 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
-load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
+load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 DEFAULT_GRAFANA_TAG = "10.0.3"
 DEFAULT_GRAFANA_SHA = "sha256:da34adacd374f6a4d539669a8d5dbda781aa004d429b2058aba9434a9224a04b"
@@ -11,14 +10,10 @@ def repositories(use_custom_container = False):
     Args:
         use_custom_container: use a custom container for grafana.
     """
-    container_repositories()
-
     if not use_custom_container:
-        container_pull(
+        oci_pull(
             name = "io_bazel_rules_grafana_docker",
-            registry = "index.docker.io",
-            repository = "grafana/grafana",
-            tag = DEFAULT_GRAFANA_TAG,
+            image = "index.docker.io/grafana/grafana",
             digest = DEFAULT_GRAFANA_SHA,
         )
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,7 +1,8 @@
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@io_bazel_rules_grafana//grafana:grafana.bzl", "json_dashboards", "py_dashboards")
 load("@io_bazel_rules_grafana//grafana:image.bzl", "grafana_image")
 load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_oci//oci:defs.bzl", "oci_tarball")
 
 json_dashboards(
     name = "json_dashboards",
@@ -70,7 +71,13 @@ grafana_image(
     datasources = [":test_datasources.yaml"],
 )
 
-container_test(
+oci_tarball(
+    name = "grafana_tarball",
+    image = ":grafana",
+    repo_tags = ["grafana:latest"],
+)
+
+container_structure_test(
     name = "grafana_docker_test",
     configs = ["docker_tests.yaml"],
     image = ":grafana",
@@ -85,7 +92,13 @@ grafana_image(
     plugins = ["@grafana_plotly_plugin//:plugin"],
 )
 
-container_test(
+oci_tarball(
+    name = "grafana_with_plugins_tarball",
+    image = ":grafana_with_plugins",
+    repo_tags = ["grafana_with_plugins:latest"],
+)
+
+container_structure_test(
     name = "grafana_with_plugins_docker_test",
     configs = ["docker_with_plugins_tests.yaml"],
     image = ":grafana_with_plugins",


### PR DESCRIPTION
rules_docker has been deprecated and is not longer supported. rules_oci is its replacement and is actively maintained. This change migrates grafana_image to use be an OCI image.

Fixes https://github.com/etsy/rules_grafana/issues/31