### PR TITLE
Disallow dashboards with the same file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ grafana_repositories()
 ```
 
 `rules_grafana` also depends on [`rules_python`](https://github.com/bazelbuild/rules_python) and
-[`rules_docker`](https://github.com/bazelbuild/rules_docker).
+[`rules_oci`](https://github.com/bazel-contrib/rules_oci?tab=readme-ov-file#installation).
 If you don't already have these libraries in your `WORKSPACE`,
 add them above the previous block:
 
 - [`rules_python` setup](https://github.com/bazelbuild/rules_python#setup).
-- [`rules_docker` setup](https://github.com/bazelbuild/rules_docker#setup).
+- [`rules_oci` setup](https://github.com/bazel-contrib/rules_oci?tab=readme-ov-file#installation).
 
 ## Bazel compatibility
 

--- a/grafana/image.bzl
+++ b/grafana/image.bzl
@@ -1,5 +1,5 @@
 load("@rules_oci//oci:defs.bzl", "oci_image")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg_grafana//pkg:tar.bzl", "pkg_tar")
 
 def grafana_image(name, datasources, dashboards, plugins = [], env = {}, visibility = None):
     """
@@ -15,6 +15,7 @@ def grafana_image(name, datasources, dashboards, plugins = [], env = {}, visibil
     """
     pkg_tar(
         name = "%s_grafana_etc" % name,
+        allow_duplicates_with_different_content = False,
         package_dir = "/etc/grafana",
         srcs = [
             "@io_bazel_rules_grafana//grafana:config/grafana.ini",
@@ -24,18 +25,21 @@ def grafana_image(name, datasources, dashboards, plugins = [], env = {}, visibil
 
     pkg_tar(
         name = "%s_grafana_dashboards_provisioning" % name,
+        allow_duplicates_with_different_content = False,
         package_dir = "/etc/grafana/provisioning/dashboards/",
         srcs = ["@io_bazel_rules_grafana//grafana:config/provisioning/dashboards.yaml"],
     )
 
     pkg_tar(
         name = "%s_grafana_datasources_provisioning" % name,
+        allow_duplicates_with_different_content = False,
         package_dir = "/etc/grafana/provisioning/datasources/",
         srcs = datasources,
     )
 
     pkg_tar(
         name = "%s_grafana_plugins" % name,
+        allow_duplicates_with_different_content = False,
         package_dir = "/var/lib/grafana/plugins/",
         # rules_docker directory structure did not include external directory.
         strip_prefix = "/external",
@@ -44,9 +48,12 @@ def grafana_image(name, datasources, dashboards, plugins = [], env = {}, visibil
 
     pkg_tar(
         name = "%s_dashboards" % name,
+        allow_duplicates_with_different_content = False,
         # Dashboard files must be writable for entrypoint.sh.
         mode = "0o666",  # octal
         package_dir = "/var/lib/grafana/dashboards/",
+        # If strip prefix is not set, directory structure is flattened which we don't want.
+        strip_prefix = ".",
         srcs = dashboards,
     )
 

--- a/grafana/workspace.bzl
+++ b/grafana/workspace.bzl
@@ -17,6 +17,18 @@ def repositories(use_custom_container = False):
             digest = DEFAULT_GRAFANA_SHA,
         )
 
+    # rules_pkg
+    http_archive(
+        # Use our own namespace of rules_pkg so we don't conflict with others.
+        name = "rules_pkg_grafana",
+        sha256 = "e93b7309591cabd68828a1bcddade1c158954d323be2205063e718763627682a",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.10.0/rules_pkg-0.10.0.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.10.0/rules_pkg-0.10.0.tar.gz",
+        ],
+    )
+    # end rules_pkg
+
 def grafana_plugin(name, urls, sha256, type = None):
     http_archive(
         name = name,


### PR DESCRIPTION
Previously these dashboards would overwrite one
another with a warning displayed in the user's
console. Now such conflicts are treated as an
error.

Fixes #10