### PR TITLE
remove strip_prefix arg

### DIFF
--- a/grafana/grafana.bzl
+++ b/grafana/grafana.bzl
@@ -77,8 +77,6 @@ def _py_dashboard_builder(src, deps = None):
     grafana_deps = requirement("grafanalib")
     py_binary(
         name = py_binary_name,
-        python_version = "PY3",
-        srcs_version = "PY3",
         srcs = [src],
         deps = [grafana_deps] + deps,
         main = src,

--- a/grafana/image.bzl
+++ b/grafana/image.bzl
@@ -52,8 +52,6 @@ def grafana_image(name, datasources, dashboards, plugins = [], env = {}, visibil
         # Dashboard files must be writable for entrypoint.sh.
         mode = "0o666",  # octal
         package_dir = "/var/lib/grafana/dashboards/",
-        # If strip prefix is not set, directory structure is flattened which we don't want.
-        strip_prefix = ".",
         srcs = dashboards,
     )
 


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

> Please include a brief summary of the changes.

The `strip_prefix` arg for pkg_tar adds another folder to the built layer:

```
/var/lib/grafana/dashboards
/var/lib/grafana/dashboards/dashboards
/var/lib/grafana/dashboards/dashboards/orca_sdk
/var/lib/grafana/dashboards/dashboards/orca_sdk/orca_sdk_components.generated.json
/var/lib/grafana/dashboards/dashboards/mmx
/var/lib/grafana/dashboards/dashboards/mmx/mmx_slas.generated.json
```

This breaks our grafana config

## Context / Why are we making this change?

> Please include details on why this change is necessary, and any applicable tickets, design docs, or documentation links.

## Testing and QA Plan

> How has this work been tested or QA'd?

## Impact

> What are the implications of these changes? Are there any cross-cutting concerns to keep in mind?
